### PR TITLE
Improve workflow: replace set-env

### DIFF
--- a/.github/workflows/java-go-python.yaml
+++ b/.github/workflows/java-go-python.yaml
@@ -136,8 +136,8 @@ jobs:
         run: |
           export OWNER="$(echo "${{ github.repository }}" | awk -F / '{print $1}' | sed -e "s/:refs//")"
           export REPO="$(echo "${{ github.repository }}" | awk -F / '{print $2}' | sed -e "s/:refs//")"
-          echo "::set-env name=REPOSITORY_OWNER::$OWNER"
-          echo "::set-env name=REPOSITORY_NAME::$REPO"
+          echo "REPOSITORY_OWNER=$OWNER" >> $GITHUB_ENV
+          echo "REPOSITORY_NAME=$REPO" >> $GITHUB_ENV
       - name: Send report to commit
         uses: joonvena/robotframework-reporter-action@v0.1
         env:


### PR DESCRIPTION
As pointed by GitHub Actions runner output and [GitHub Actions changelog](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands) set-env is being deprecrated due to moderate security vulnerability.

```txt
The `set-env` command is deprecated and will be disabled soon. 
Please upgrade to using Environment Files. 
For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
```
```bash
echo "::set-env name=REPOSITORY_OWNER::$OWNER"
```
replaced with:
```bash
echo "REPOSITORY_OWNER=$OWNER" >> $GITHUB_ENV
```